### PR TITLE
텍스트뷰 비활성, 그룹 탈퇴 메시지, 토론 게시글 화면 전환

### DIFF
--- a/Plog/DiscussionBoardViewController.swift
+++ b/Plog/DiscussionBoardViewController.swift
@@ -66,6 +66,8 @@ class DiscussionBoardViewController: UIViewController,UITableViewDataSource,UITa
     }
     
     func setDiscussionData(){
+        //게시글 작성하고 새로 목록 불러올 때 배열 비우고 받아옴
+        self.boardTitle = []
         let db = Firestore.firestore()
         db.collection("discussion").getDocuments(){(querySnapshot, err) in
             if let err = err {

--- a/Plog/DiscussionRegisterViewController.swift
+++ b/Plog/DiscussionRegisterViewController.swift
@@ -48,9 +48,9 @@ class DiscussionRegisterViewController: UIViewController, UITextFieldDelegate,UI
         uuid = UUID().uuidString
         storageRef = Storage.storage().reference() //img
         self.sendFireStore()
-  //      self.moveToNewVC()
+        self.moveToNewVC()
         print("success")
-        dismiss(animated: true)
+        //dismiss(animated: true)
     }
 
     override func viewDidLoad() {
@@ -92,16 +92,23 @@ class DiscussionRegisterViewController: UIViewController, UITextFieldDelegate,UI
     }
     
     func moveToNewVC() {
-        print("done")
-        let nextVC = UIStoryboard(name: "DiscussionPost", bundle: nil).instantiateViewController(withIdentifier: "DiscussionPostViewController") as! DiscussionPostViewController
-        
-        //토론 게시판으로 이동하는 코드
-  //      let newVC = UIStoryboard(name: "DiscussionBoardStoryboard", bundle: nil).instantiateViewController(withIdentifier: "DiscussionBoardViewController") as! DiscussionBoardViewController
-        nextVC.modalPresentationStyle = .fullScreen
-        nextVC.modalTransitionStyle = .crossDissolve
+        //이전 화면
+        guard let pvc = self.presentingViewController else {return}
+        //현재 화면 dismiss
+        self.dismiss(animated: true){
+            //다음 화면 설정
+            let nextVC = UIStoryboard(name: "DiscussionPost", bundle: nil).instantiateViewController(withIdentifier: "DiscussionPostViewController") as! DiscussionPostViewController
 
-        nextVC.receiveId = self.uuid
-        self.present(nextVC, animated: true, completion: nil)
+            nextVC.modalPresentationStyle = .fullScreen
+            nextVC.modalTransitionStyle = .crossDissolve
+
+            nextVC.receiveId = self.uuid
+            
+            //(현재화면은 사라진 상태이므로) 이전화면에서 present 해야함
+            pvc.present(nextVC, animated: true, completion: nil)
+            //이전화면 viewdidload로 갱신
+            pvc.viewDidLoad()
+        }
     }
     
     // textField 글자 수 제한

--- a/Plog/GroupDetailView.swift
+++ b/Plog/GroupDetailView.swift
@@ -8,6 +8,7 @@ struct GroupDetailView: View {
     var userId: Int64
     
     @Environment(\.dismiss) var dismiss
+    @State private var showingAlert = false
 
     var body: some View {
         VStack {
@@ -23,7 +24,7 @@ struct GroupDetailView: View {
                         //탈퇴: 그룹에서 사용자 정보 삭제
                         Firestore.firestore().collection("group").document(group.id).collection("member").document(String(userId)).delete()
                     }
-                    dismiss()
+                    showingAlert = true
                 } label: {
                     Text("탈퇴")
                         .padding(5)
@@ -31,6 +32,9 @@ struct GroupDetailView: View {
                 .foregroundColor(Color(hue: 0.397, saturation: 0.87, brightness: 0.509))
                 .overlay(RoundedRectangle(cornerRadius: 5).stroke(.green, lineWidth: 2))
                 .padding()
+                .alert("그룹에서 탈퇴하였습니다.", isPresented: $showingAlert) {
+                    Button("확인") { dismiss() }
+                }
             }
             ScrollView {
                 VStack(alignment: .leading) {

--- a/Plog/View/ApostDetail.storyboard
+++ b/Plog/View/ApostDetail.storyboard
@@ -83,7 +83,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="많음" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="hJQ-j6-tDH">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="많음" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJQ-j6-tDH">
                                                 <rect key="frame" x="135" y="732" width="208" height="40"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -91,7 +91,7 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="플라스틱" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="mvq-me-tOz">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="플라스틱" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mvq-me-tOz">
                                                 <rect key="frame" x="219" y="804" width="124" height="40"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -99,7 +99,7 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="언덕 길이 많은 코스" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="iKw-Z7-zXa">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="언덕 길이 많은 코스" textAlignment="justified" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKw-Z7-zXa">
                                                 <rect key="frame" x="22" y="921" width="355" height="122"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>


### PR DESCRIPTION
1. 탈퇴로 그룹이 삭제될 때 데이터 불러오는 속도 차이로 인해 데이터가 이상하게 나타나는 오류 해결 위해 탈퇴 알림 메시지 추가
2. 코스 후기 게시글(스토리보드)에서 텍스트뷰 비활성화 되도록 수정
3. 토론 게시물 작성 버튼 누르면 작성 페이지->게시글 페이지로 이동. X버튼 클릭 시 토론 게시글 목록이 뜨도록 함.